### PR TITLE
Fix Smoothscroll for relative URLs other than Base URL

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,11 +1,15 @@
 # main links
+# version: 1(all links) OR 2(internal links) - mandatory field
 main:
   - title: "< ABOUT />"
     url: https://kamandprompt.github.io/index.html#about
+    version: 1
   - title: "< EVENTS />"
     url: /events/
+    version: 1
   - title: "< CONTACT US />"
     url: "#contact"
+    version: 2
   # - title: "Sample Posts"
   #   url: /year-archive/
   # - title: "Sample Collections"

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -5,10 +5,14 @@
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
-            {%- if link.url contains '://' -%}
-              {%- assign url = link.url -%}
+            {%- if link.url contains '#' -%}
+              {%- assign url = page.url | relative_url | append: link.url -%}
             {%- else -%}
-              {%- assign url = link.url | relative_url -%}
+              {%- if link.url contains '://' -%}
+                {%- assign url = link.url -%}
+              {%- else -%}
+                {%- assign url = link.url | relative_url -%}
+              {%- endif -%}
             {%- endif -%}
             <li class="masthead__menu-item">
               <a href="{{ url }}" {% if link.description %}title="{{ link.description }}"{% endif %}>{{ link.title }}</a>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -5,7 +5,7 @@
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
-            {%- if link.url contains '#' -%}
+            {%- if link.version == 2 -%}
               {%- assign url = page.url | relative_url | append: link.url -%}
             {%- else -%}
               {%- if link.url contains '://' -%}


### PR DESCRIPTION
- Add feature of internal links in Navbar
- Now links of the form .../#address will link to the same page
- Smooth Scroll works for link to Contact Us on Events page